### PR TITLE
[FIX] Account for elapsed simulation time when delaying for targetFps

### DIFF
--- a/tenMinutePhysics/16-GPUCloth.py
+++ b/tenMinutePhysics/16-GPUCloth.py
@@ -796,9 +796,9 @@ def timerCallback(val):
     global frameNr
     frameNr = frameNr + 1
     numFpsFrames = 30
+    currentTime = time.perf_counter()
 
     if frameNr % numFpsFrames == 0:
-        currentTime = time.time()
         passedTime = currentTime - prevTime
         prevTime = currentTime
         fps = math.floor(numFpsFrames / passedTime)
@@ -812,7 +812,8 @@ def timerCallback(val):
     camera.setView()
     camera.handleKeys()
 
-    glutTimerFunc(math.floor(1000.0 / targetFps), timerCallback, 0)
+    elapsed_ms = (time.perf_counter() - currentTime) * 1000
+    glutTimerFunc(max(0, math.floor((1000.0 / targetFps) - elapsed_ms)), timerCallback, 0)
 
 # -----------------------------------------------------------
 


### PR DESCRIPTION
@matthias-research

This PR accounts for a minor bug in the `timerCallback` function which resulted in it never reaching the target framerate.

When delaying for the next frame, it did not take into account the time it takes to simulate the cloth.

These should be the minimal set of changes to account for this issue; you can see the difference more starkly by reducing `clothNumX` and `clothNumY` (it should reach 60fps now where it did not before).