### PR TITLE
Change addAttribute to setAttribute in softBody.html

### DIFF
--- a/challenges/softBody.html
+++ b/challenges/softBody.html
@@ -142,7 +142,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 					// visual edge mesh
 
 					var geometry = new THREE.BufferGeometry();
-					geometry.addAttribute('position', new THREE.BufferAttribute(vertices, 3));
+					geometry.setAttribute('position', new THREE.BufferAttribute(vertices, 3));
 					geometry.setIndex(tetEdgeIds);
 					this.edgeMesh = new THREE.LineSegments(geometry);
 					this.edgeMesh.userData = this;	// for raycasting
@@ -154,7 +154,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 					this.visVerts = visVerts;
 					this.numVisVerts = visVerts.length / 4;
 					geometry = new THREE.BufferGeometry();
-					geometry.addAttribute('position', new THREE.BufferAttribute(
+					geometry.setAttribute('position', new THREE.BufferAttribute(
 						new Float32Array(3 * this.numVisVerts), 3));
 					geometry.setIndex(visTriIds);
 					this.visMesh = new THREE.Mesh(geometry, visMaterial);


### PR DESCRIPTION
The [Soft Body Simulation](https://matthias-research.github.io/pages/challenges/softBody.html) page seems to be broken. For me, the canvas stays blank white and I'm getting the following error in the console:
`Uncaught TypeError: geometry.addAttribute is not a function`

It looks like three.js renamed the `addAttribute()` method on `BufferGeometry` to `setAttribute()` at some point.

I tried changing every `addAttribute` to `setAttribute` and that seemed to resolve the issue.

