### PR TITLE
Switch threejs imports to use CDN with static version (fix OrbitControls import 404 in many demos)

### DIFF
--- a/challenges/bodyChainPBD.html
+++ b/challenges/bodyChainPBD.html
@@ -77,7 +77,7 @@
         <a href = "https://github.com/matthias-research/pages/blob/master/challenges/PBD.js" class ="button" target = "_blank">PBD.js</a>        
         <a href = "https://github.com/matthias-research/pages/blob/master/challenges/bodyChainPBD.html" class ="button" target = "_blank">bodyChainPBD.html</a>        
 
-		<script src="https://threejs.org/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.147.0/build/three.min.js"></script>
 
 		<script src="PBD.js"></script>
 

--- a/challenges/softBody.html
+++ b/challenges/softBody.html
@@ -79,8 +79,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 		<br><br>		
         <div id="container"></div>
         
-		<script src="https://threejs.org/build/three.js"></script>
-		<script src='https://threejs.org/examples/js/controls/OrbitControls.js'></script>		
+		<script src="https://unpkg.com/three@0.147.0/build/three.min.js"></script>
+		<script src="https://unpkg.com/three@0.147.0/examples/js/controls/OrbitControls.js"></script>		
 		<script>
 
 			var container = document.getElementById( 'container' );

--- a/tenMinutePhysics/02-cannonball3d.html
+++ b/tenMinutePhysics/02-cannonball3d.html
@@ -29,8 +29,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 		<br><br>		
         <div id="container"></div>
         
-		<script src="https://threejs.org/build/three.js"></script>
-		<script src='https://threejs.org/examples/js/controls/OrbitControls.js'></script>		
+		<script src="https://unpkg.com/three@0.147.0/build/three.min.js"></script>
+		<script src="https://unpkg.com/three@0.147.0/examples/js/controls/OrbitControls.js"></script>	
 		<script>
 			
 			var threeScene;

--- a/tenMinutePhysics/02-cannonballVR.html
+++ b/tenMinutePhysics/02-cannonballVR.html
@@ -27,7 +27,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 		<br><br>		
         <div id="container"></div>
         
-		<script src="https://threejs.org/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.147.0/build/three.min.js"></script>
 		<script>
 			
             // ------------------------------------------------------------------

--- a/tenMinutePhysics/08-interaction.html
+++ b/tenMinutePhysics/08-interaction.html
@@ -39,8 +39,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 		<br><br>		
         <div id="container"></div>
         
-		<script src="https://threejs.org/build/three.js"></script>
-		<script src='https://threejs.org/examples/js/controls/OrbitControls.js'></script>		
+		<script src="https://unpkg.com/three@0.147.0/build/three.min.js"></script>
+		<script src="https://unpkg.com/three@0.147.0/examples/js/controls/OrbitControls.js"></script>		
 		<script>
 			
 			var gThreeScene;

--- a/tenMinutePhysics/10-softBodies.html
+++ b/tenMinutePhysics/10-softBodies.html
@@ -46,8 +46,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 		<br><br>		
         <div id="container"></div>
         
-		<script src="https://threejs.org/build/three.js"></script>
-		<script src='https://threejs.org/examples/js/controls/OrbitControls.js'></script>		
+		<script src="https://unpkg.com/three@0.147.0/build/three.min.js"></script>
+		<script src="https://unpkg.com/three@0.147.0/examples/js/controls/OrbitControls.js"></script>	
 		<script>
 
 			// ----- math on vector arrays -------------------------------------------------------------

--- a/tenMinutePhysics/11-hashing.html
+++ b/tenMinutePhysics/11-hashing.html
@@ -42,8 +42,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 		<br><br>		
         <div id="container"></div>
         
-		<script src="https://threejs.org/build/three.js"></script>
-		<script src='https://threejs.org/examples/js/controls/OrbitControls.js'></script>		
+		<script src="https://unpkg.com/three@0.147.0/build/three.min.js"></script>
+		<script src="https://unpkg.com/three@0.147.0/examples/js/controls/OrbitControls.js"></script>		
 		<script>
 			
 			var threeScene;

--- a/tenMinutePhysics/12-softBodySkinning.html
+++ b/tenMinutePhysics/12-softBodySkinning.html
@@ -48,8 +48,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 		<br><br>		
         <div id="container"></div>
         
-		<script src="https://threejs.org/build/three.js"></script>
-		<script src='https://threejs.org/examples/js/controls/OrbitControls.js'></script>		
+		<script src="https://unpkg.com/three@0.147.0/build/three.min.js"></script>
+		<script src="https://unpkg.com/three@0.147.0/examples/js/controls/OrbitControls.js"></script>		
 		<script>
 
 			// ----- math on vector arrays -------------------------------------------------------------

--- a/tenMinutePhysics/14-cloth.html
+++ b/tenMinutePhysics/14-cloth.html
@@ -50,8 +50,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 		<br><br>		
         <div id="container"></div>
         
-		<script src="https://threejs.org/build/three.js"></script>
-		<script src='https://threejs.org/examples/js/controls/OrbitControls.js'></script>		
+		<script src="https://unpkg.com/three@0.147.0/build/three.min.js"></script>
+		<script src="https://unpkg.com/three@0.147.0/examples/js/controls/OrbitControls.js"></script>		
 		<script>
 
 			// ----- math on vector arrays -------------------------------------------------------------

--- a/tenMinutePhysics/15-selfCollision.html
+++ b/tenMinutePhysics/15-selfCollision.html
@@ -51,8 +51,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 		<br><br>		
         <div id="container"></div>
         
-		<script src="https://threejs.org/build/three.js"></script>
-		<script src='https://threejs.org/examples/js/controls/OrbitControls.js'></script>		
+		<script src="https://unpkg.com/three@0.147.0/build/three.min.js"></script>
+		<script src="https://unpkg.com/three@0.147.0/examples/js/controls/OrbitControls.js"></script>		
 		<script>
 
 			// ----- math on vector arrays -------------------------------------------------------------

--- a/tenMinutePhysics/contribs/pendulum3d.html
+++ b/tenMinutePhysics/contribs/pendulum3d.html
@@ -30,8 +30,8 @@ Housz@sdust.edu.cn
 <body>
     <h1>Pendulum 3D</h1>
 
-    <script src="https://threejs.org/build/three.js"></script>
-    <script src='https://threejs.org/examples/js/controls/OrbitControls.js'></script>
+    <script src="https://unpkg.com/three@0.147.0/build/three.min.js"></script>
+	<script src="https://unpkg.com/three@0.147.0/examples/js/controls/OrbitControls.js"></script>
 
     <p>
         dt: 1/60 &nbsp&nbsp

--- a/tenMinutePhysics/contribs/pendulumTrail.html
+++ b/tenMinutePhysics/contribs/pendulumTrail.html
@@ -30,8 +30,8 @@ Housz@sdust.edu.cn
 <body>
     <h1>Pendulum 3D</h1>
 
-    <script src="https://threejs.org/build/three.js"></script>
-    <script src='https://threejs.org/examples/js/controls/OrbitControls.js'></script>
+    <script src="https://unpkg.com/three@0.147.0/build/three.min.js"></script>
+	<script src="https://unpkg.com/three@0.147.0/examples/js/controls/OrbitControls.js"></script>
 
     <p>
         <button id="btnRun" class="button" onclick="run()">Run</button>


### PR DESCRIPTION
Fixes #16.

Currently, `three.js` and `OrbitControls.js` are imported from the threejs.org Github Pages site in many demos.
```
<script src="https://threejs.org/build/three.js"></script>
<script src='https://threejs.org/examples/js/controls/OrbitControls.js'></script>
```

As of version [0.148.0](https://github.com/mrdoob/three.js/releases/tag/r148) (5 days ago), vanilla `js` files are no longer hosted for example/addon code. This breaks many TenMinutePhysics demos with errors similar to the following:
```
[Error] Failed to load resource: the server responded with a status of 404 () (OrbitControls.js, line 0)
[Error] TypeError: undefined is not a constructor (evaluating 'new THREE.OrbitControls(gCamera, gRenderer.domElement)')
	initThreeScene (15-selfCollision.html:717)
	Global Code (15-selfCollision.html:872)
```

threejs.org now [recommends](https://threejs.org/docs/index.html#manual/en/introduction/Installation) the use of `importmap` and js modules. This PR fixes the issue with minimal changes by switching all demos to import `three.js` from a well-known CDN ([unpkg](https://unpkg.com)) and fixing the version to `0.147.0`, the last release including `examples/js/controls/OrbitControls.js`.
```
<script src="https://unpkg.com/three@0.147.0/build/three.min.js"></script>
<script src="https://unpkg.com/three@0.147.0/examples/js/controls/OrbitControls.js"></script>
```
