### PR TITLE
Fix minor boundary issue in FLIP demo

### DIFF
--- a/tenMinutePhysics/18-flip.html
+++ b/tenMinutePhysics/18-flip.html
@@ -456,10 +456,10 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 					}
 					else {
 						var offset = component == 0 ? n : 1;
-						var valid0 = this.cellType[nr0] != AIR_CELL || this.cellType[nr0 - offset] != AIR_CELL ? 1.0 : 0.0;
-						var valid1 = this.cellType[nr1] != AIR_CELL || this.cellType[nr1 - offset] != AIR_CELL ? 1.0 : 0.0;
-						var valid2 = this.cellType[nr2] != AIR_CELL || this.cellType[nr2 - offset] != AIR_CELL ? 1.0 : 0.0;
-						var valid3 = this.cellType[nr3] != AIR_CELL || this.cellType[nr3 - offset] != AIR_CELL ? 1.0 : 0.0;
+						var valid0 = this.cellType[nr0] == FLUID_CELL || this.cellType[nr0 - offset] == FLUID_CELL ? 1.0 : 0.0;
+						var valid1 = this.cellType[nr1] == FLUID_CELL || this.cellType[nr1 - offset] == FLUID_CELL ? 1.0 : 0.0;
+						var valid2 = this.cellType[nr2] == FLUID_CELL || this.cellType[nr2 - offset] == FLUID_CELL ? 1.0 : 0.0;
+						var valid3 = this.cellType[nr3] == FLUID_CELL || this.cellType[nr3 - offset] == FLUID_CELL ? 1.0 : 0.0;
 
 						var v = this.particleVel[2 * i + component];
 						var d = valid0 * d0 + valid1 * d1 + valid2 * d2 + valid3 * d3;


### PR DESCRIPTION
In the FLIP demo, when transferring velocities to particles, solid cells should not be considered valid.

Particles in contact with the left wall were constantly pushed downwards, this fixes that. It doesn't really matter except that it means the fluid doesn't come to rest. It still doesn't fully settle as there are some other effects on the other edges, not sure if it's worth trying to fix these though.

PS Thank you for making these tutorials, they're excellent.